### PR TITLE
Implement theme override argument

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,10 @@ pub struct Config {
     /// Don't highlight output
     #[structopt(long = "plain")]
     pub plain: bool,
+
+    /// Specify a theme override for the pretty printer
+    #[structopt(name = "THEME", long="theme")]
+    pub theme : Option<String>,
 }
 
 /// The structopt enum, which serves as an adapter so that the config options

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,13 @@ pub fn inspect(config: &Config) -> Result<(), InspectError> {
     if config.plain {
         println!("{}", output);
     } else {
-        let printer = PrettyPrinter::default().language("rust").build()?;
+        let mut builder = PrettyPrinter::default();
+        builder.language("rust");
+        if let Some(theme) = &config.theme {
+            builder.theme(theme.clone());
+        }
+
+        let printer = builder.build()?;
         let header = config.input.to_owned().unwrap_or(env::current_dir()?);
         printer.string_with_header(output, header.to_string_lossy().to_string())?;
     }


### PR DESCRIPTION
Fixes #17 

Allow the user to specify a theme override for the pretty printer. If the theme doesn't exist pretty printer outputs a warning. 

@mre I do not know what themes are available. I had a look in pretty printer and the only theme I can deduce (from the source) is the default one. The other themes are stored in a binary format. Is there some list of the available themes to test this PR with?
