### PR TITLE
Support graphviz/dot files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,8 @@ pub struct Config {
     pub files: Option<(String, String)>,
 
     /// rustc "unpretty" parameters
+    /// 
+    /// *Note*: For `--unpretty=flowgraph=[symbol]` you need to have `dot` on your PATH.
     #[structopt(long = "unpretty", default_value = "hir")]
     pub unpretty: String,
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,12 @@ pub enum InspectError {
     /// Error while invoking prettyprint
     #[fail(display = "{}", _0)]
     PrettyPrint(String),
+    /// Error while trying to generate a flowgraph
+    #[fail(display = "{}", _0)]
+    Flowgraph(String),
+    /// Error invoking `dot`
+    #[fail(display = "{}", _0)]
+    DotExec(#[fail(cause)] IoError),
     /// Other error
     #[fail(display = "{}", _0)]
     Generic(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@
 
 use std::env;
 use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
 use std::fs::File;
 use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
 
 /// Available configuration settings when using cargo-inspect as a library
 pub mod config;
@@ -63,39 +63,46 @@ pub fn inspect(config: &Config) -> Result<(), InspectError> {
 
     if config.plain {
         println!("{}", output);
-    }
-    else if config.unpretty.starts_with("flowgraph"){
+    } else if config.unpretty.starts_with("flowgraph") {
         if let Some(path) = &config.input {
             let input_path = PathBuf::from(path);
-            let mut output_path = PathBuf::new();
-            output_path.push(input_path.file_name().unwrap());
+
+            // Extract the file name from our input path.
+            let file_name = input_path
+                .file_name()
+                .ok_or(InspectError::Flowgraph(String::from(
+                    "Invalid path found. The input path should be a file.",
+                )))?;
+
+            let mut output_path = PathBuf::from(file_name);
             output_path.set_extension("png");
 
             // Create a temporary file to dump out the plain output
             let tmp_file_path = tmpfile()?;
-            {
-                let mut file = File::create(&tmp_file_path)?;
-                {
-                    file.write_all(output.as_bytes())?;
-                }
-            }
+            let mut file = File::create(&tmp_file_path)?;
+            file.write_all(output.as_bytes())?;
 
             // For now setup the correct `dot` arguments to write to a png
-            let output_str = output_path.to_str()
-                .ok_or(InspectError::Generic(String::from("Failed to convert output path to string.")))?;
-            let input_str = tmp_file_path.to_str()
-                .ok_or(InspectError::Generic(String::from("Failed to convert temporary path to string.")))?;
+            let output_str = output_path
+                .to_str()
+                .ok_or(InspectError::Flowgraph(String::from(
+                    "Failed to convert output path to string.",
+                )))?;
 
-            let args = [
-                "-Tpng",
-                "-o", output_str,
-                input_str,
-            ];
+            let input_str = tmp_file_path
+                .to_str()
+                .ok_or(InspectError::Flowgraph(String::from(
+                    "Failed to convert temporary path to string.",
+                )))?;
+
             log::info!("Writing \"{}\"...", output_str);
 
-            Command::new("dot").args(&args).spawn()?;
+            let args = ["-Tpng", "-o", output_str, input_str];
+            Command::new("dot")
+                .args(&args)
+                .spawn()
+                .map_err(|e| InspectError::DotExec(e))?;
         }
-
     } else {
         let mut builder = PrettyPrinter::default();
         builder.language("rust");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
+use std::fs::File;
+use std::io::Write;
 
 /// Available configuration settings when using cargo-inspect as a library
 pub mod config;
@@ -60,6 +63,39 @@ pub fn inspect(config: &Config) -> Result<(), InspectError> {
 
     if config.plain {
         println!("{}", output);
+    }
+    else if config.unpretty.starts_with("flowgraph"){
+        if let Some(path) = &config.input {
+            let input_path = PathBuf::from(path);
+            let mut output_path = PathBuf::new();
+            output_path.push(input_path.file_name().unwrap());
+            output_path.set_extension("png");
+
+            // Create a temporary file to dump out the plain output
+            let tmp_file_path = tmpfile()?;
+            {
+                let mut file = File::create(&tmp_file_path)?;
+                {
+                    file.write_all(output.as_bytes())?;
+                }
+            }
+
+            // For now setup the correct `dot` arguments to write to a png
+            let output_str = output_path.to_str()
+                .ok_or(InspectError::Generic(String::from("Failed to convert output path to string.")))?;
+            let input_str = tmp_file_path.to_str()
+                .ok_or(InspectError::Generic(String::from("Failed to convert temporary path to string.")))?;
+
+            let args = [
+                "-Tpng",
+                "-o", output_str,
+                input_str,
+            ];
+            log::info!("Writing \"{}\"...", output_str);
+
+            Command::new("dot").args(&args).spawn()?;
+        }
+
     } else {
         let mut builder = PrettyPrinter::default();
         builder.language("rust");


### PR DESCRIPTION
As discussed in  #26 , this PR adds the ability to render out a flowgraph to a file. 

When `--unpretty=flowgraph=[symbol]` is used we pass the unformatted output through `dot`. For this to work `dot` has to be in the PATH though. 


