### PR TITLE
Change the default output for a flowgraph to a vector format

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,11 @@ pub struct Config {
     #[structopt(long = "unpretty", default_value = "hir")]
     pub unpretty: String,
 
+    /// Override for the format that gets outputted when the `unpretty` mode
+    /// is set to `flowgraph`
+    #[structopt(long = "format", default_value = "svg")]
+    pub format: String,
+
     /// Print the original code as a comment above the desugared code
     #[structopt(short = "v", long = "verbose")]
     pub verbose: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub fn inspect(config: &Config) -> Result<(), InspectError> {
                 )))?;
 
             let mut output_path = PathBuf::from(file_name);
-            let ext = "svg";
+            let ext = &config.format;
             output_path.set_extension(&ext);
 
             // Create a temporary file to dump out the plain output

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,8 @@ pub fn inspect(config: &Config) -> Result<(), InspectError> {
                 )))?;
 
             let mut output_path = PathBuf::from(file_name);
-            output_path.set_extension("png");
+            let ext = "svg";
+            output_path.set_extension(&ext);
 
             // Create a temporary file to dump out the plain output
             let tmp_file_path = tmpfile()?;
@@ -97,7 +98,7 @@ pub fn inspect(config: &Config) -> Result<(), InspectError> {
 
             log::info!("Writing \"{}\"...", output_str);
 
-            let args = ["-Tpng", "-o", output_str, input_str];
+            let args = [&format!("-T{}", ext), "-o", output_str, input_str];
             Command::new("dot")
                 .args(&args)
                 .spawn()


### PR DESCRIPTION
After some thinking I realised rendering flowgraphs to pngs is nice but imposes problems with big graphs. 

`dot` also allows rendering to a vector format (svg). This PR changes the default format to svg. 

Maybe this can be extended to allow a choice through a command line parameter for the user to choose in what format to render? 